### PR TITLE
Fix vibration, add sticky setting

### DIFF
--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -50,6 +50,13 @@
 		        android:layout_marginRight="6dip"
 		        android:layout_marginTop="8dip"
 		        android:hint="@string/message_hint" />
+		    
+		    <CheckBox
+		        android:id="@+id/checkBox2"
+		        android:layout_width="wrap_content"
+		        android:layout_height="wrap_content"
+		        android:text="@string/sticky_label"
+		        android:checked="true" />
 		
 		    <RadioButton
 		        android:id="@+id/radioButton2"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -32,6 +32,9 @@
     <!-- Hint text in the title edit text -->
     <string name="title_hint">MetaWatch notification title</string>
     
+    <!-- Label for the sticky checkbox -->
+    <string name="sticky_label">Sticky notification</string>
+    
     <!-- Hint text in the message edit text -->
     <string name="id_hint">widget unique id</string>
     

--- a/src/org/metawatch/manager/locale/bundle/PluginBundleManager.java
+++ b/src/org/metawatch/manager/locale/bundle/PluginBundleManager.java
@@ -81,21 +81,21 @@ public final class PluginBundleManager
     /**
      * Type: {@code String}
      * <p>
-     * Whether vibration is enabled for the event.
+     * How long the watch should vibrate in each cycle (in milliseconds).
      */
     public static final String BUNDLE_EXTRA_INT_VIBRATE_ON = "org.metawatch.manager.locale.extra.INT_VIBRATE_ON"; //$NON-NLS-1$
  
     /**
      * Type: {@code String}
      * <p>
-     * Whether vibration is enabled for the event.
+     * How long the watch should pause between vibrations in each cycle (in milliseconds).
      */
     public static final String BUNDLE_EXTRA_INT_VIBRATE_OFF = "org.metawatch.manager.locale.extra.INT_VIBRATE_OFF"; //$NON-NLS-1$
  
     /**
      * Type: {@code String}
      * <p>
-     * Whether vibration is enabled for the event.
+     * How many vibration cycles the watch should make.
      */
     public static final String BUNDLE_EXTRA_INT_VIBRATE_CYCLES = "org.metawatch.manager.locale.extra.INT_VIBRATE_CYCLES"; //$NON-NLS-1$
  

--- a/src/org/metawatch/manager/locale/bundle/PluginBundleManager.java
+++ b/src/org/metawatch/manager/locale/bundle/PluginBundleManager.java
@@ -53,6 +53,13 @@ public final class PluginBundleManager
     /**
      * Type: {@code String}
      * <p>
+     * Whether the notification should be sticky.
+     */
+    public static final String BUNDLE_EXTRA_BOOLEAN_STICKY = "org.metawatch.manager.locale.extra.BOOLEAN_STICKY"; //$NON-NLS-1$
+    
+    /**
+     * Type: {@code String}
+     * <p>
      * String id of widget.
      */
     public static final String BUNDLE_EXTRA_STRING_WIDGET_ID = "org.metawatch.manager.locale.extra.STRING_WIDGET_ID"; //$NON-NLS-1$
@@ -192,11 +199,11 @@ public final class PluginBundleManager
          * error message is more useful. (E.g. the caller will see what extras are missing, rather than just a message that there
          * is the wrong number).
          */
-        if (11 != bundle.keySet().size())
+        if (bundle.keySet().size() != 11 && bundle.keySet().size() != 12)
         {
             if (Constants.IS_LOGGABLE)
             {
-                Log.e(Constants.LOG_TAG, String.format("bundle must contain 11 keys, but currently contains %d keys: %s", Integer.valueOf(bundle.keySet().size()), bundle.keySet() //$NON-NLS-1$
+                Log.e(Constants.LOG_TAG, String.format("bundle must contain 11 or 12 keys, but currently contains %d keys: %s", Integer.valueOf(bundle.keySet().size()), bundle.keySet() //$NON-NLS-1$
                                                                                                                                                                        .toString()));
             }
             return false;

--- a/src/org/metawatch/manager/locale/receiver/FireReceiver.java
+++ b/src/org/metawatch/manager/locale/receiver/FireReceiver.java
@@ -93,6 +93,7 @@ public final class FireReceiver extends BroadcastReceiver {
 					Bundle b = new Bundle();
 					b.putString("title", bundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_TITLE));
 					b.putString("text", bundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_MESSAGE));
+					b.putBoolean("sticky", bundle.getBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_STICKY, true));
 					
 	                if( bundle.getBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_VIBRATE, false) )
 	                {

--- a/src/org/metawatch/manager/locale/receiver/FireReceiver.java
+++ b/src/org/metawatch/manager/locale/receiver/FireReceiver.java
@@ -94,7 +94,7 @@ public final class FireReceiver extends BroadcastReceiver {
 					b.putString("title", bundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_TITLE));
 					b.putString("text", bundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_MESSAGE));
 					
-	                if( bundle.containsKey(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_VIBRATE) )
+	                if( bundle.getBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_VIBRATE, false) )
 	                {
 	                	b.putInt("vibrate_on", bundle.getInt(PluginBundleManager.BUNDLE_EXTRA_INT_VIBRATE_ON));
 	                	b.putInt("vibrate_off",bundle.getInt(PluginBundleManager.BUNDLE_EXTRA_INT_VIBRATE_OFF));
@@ -113,7 +113,7 @@ public final class FireReceiver extends BroadcastReceiver {
 					createAndSendWidget(context, icon, widgetId, widgetLabel);
 					cacheWidget(context, icon, widgetId, widgetLabel);
 					
-	                if( bundle.containsKey(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_VIBRATE) )
+					if( bundle.getBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_VIBRATE, false) )
 	                {
 						Intent broadcast = new Intent("org.metawatch.manager.VIBRATE");
 						Bundle b = new Bundle();

--- a/src/org/metawatch/manager/locale/ui/EditActivity.java
+++ b/src/org/metawatch/manager/locale/ui/EditActivity.java
@@ -132,9 +132,9 @@ public final class EditActivity extends Activity
             {
                 ((EditText) findViewById(R.id.text1)).setText(forwardedBundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_MESSAGE));
                 ((EditText) findViewById(R.id.text2)).setText(forwardedBundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_TITLE));
+            	((CheckBox) findViewById(R.id.checkBox2)).setChecked(forwardedBundle.getBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_STICKY, true));
                 ((EditText) findViewById(R.id.text3)).setText(forwardedBundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_WIDGET_ID));
                 ((EditText) findViewById(R.id.text4)).setText(forwardedBundle.getString(PluginBundleManager.BUNDLE_EXTRA_STRING_WIDGET_LABEL));
-                
           
             	((CheckBox) findViewById(R.id.checkBox1)).setChecked(forwardedBundle.getBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_VIBRATE));
             	((EditText) findViewById(R.id.edit_vib_on)).setText(String.valueOf(forwardedBundle.getInt(PluginBundleManager.BUNDLE_EXTRA_INT_VIBRATE_ON)));
@@ -184,6 +184,7 @@ public final class EditActivity extends Activity
         {
             final String message = ((EditText) findViewById(R.id.text1)).getText().toString();
             final String title = ((EditText) findViewById(R.id.text2)).getText().toString();
+            final Boolean sticky = ((CheckBox) findViewById(R.id.checkBox2)).isChecked();
             
             final String widgetId = ((EditText) findViewById(R.id.text3)).getText().toString();
             final String widgetLabel = ((EditText) findViewById(R.id.text4)).getText().toString();
@@ -217,6 +218,7 @@ public final class EditActivity extends Activity
             
             resultBundle.putString(PluginBundleManager.BUNDLE_EXTRA_STRING_MESSAGE, message);
             resultBundle.putString(PluginBundleManager.BUNDLE_EXTRA_STRING_TITLE, title);
+            resultBundle.putBoolean(PluginBundleManager.BUNDLE_EXTRA_BOOLEAN_STICKY, sticky);
             
             resultBundle.putString(PluginBundleManager.BUNDLE_EXTRA_STRING_WIDGET_ID, widgetId);
             resultBundle.putString(PluginBundleManager.BUNDLE_EXTRA_STRING_WIDGET_LABEL, widgetLabel);


### PR DESCRIPTION
- Fix the handing of the vibration checkbox. Previously the watch would always vibrate (but a 0,0,0 vibration setting would only result in a "tick" from the watch).
- Correct some erroneous javadoc comments about vibration keys.
- Add a setting for whether notifications should be sticky or not (requires rm16). Backwards compatible, so old settings still work (and default to sticky).
